### PR TITLE
Remove abstract classes from astvisitors

### DIFF
--- a/src/main/java/astvisitors/AstLevelVisitor.java
+++ b/src/main/java/astvisitors/AstLevelVisitor.java
@@ -18,10 +18,8 @@ public abstract class AstLevelVisitor {
 	public abstract void visitLevel(BooleantfNode node, int level);
 	public abstract void visitLevel(StmtsNode node, int level);
 	public abstract void visitLevel(DclNode node, int level);
-	public abstract void visitLevel(TypeNode node, int level);
 	public abstract void visitLevel(DclsNode node, int level);
 	public abstract void visitLevel(While_stmtNode node, int level);
-	public abstract void visitLevel(ExprNode node, int level);
 	public abstract void visitLevel(ParametersNode node, int level);
 	public abstract void visitLevel(Built_in_funcNode node, int level);
 	public abstract void visitLevel(AdditiveExprNode node, int level);

--- a/src/main/java/astvisitors/AstVisitor.java
+++ b/src/main/java/astvisitors/AstVisitor.java
@@ -17,10 +17,8 @@ public abstract class AstVisitor {
     public abstract void visit(BooleantfNode node);
     public abstract void visit(StmtsNode node);
     public abstract void visit(DclNode node);
-    public abstract void visit(TypeNode node);
     public abstract void visit(DclsNode node);
     public abstract void visit(While_stmtNode node);
-    public abstract void visit(ExprNode node);
     public abstract void visit(ParametersNode node);
     public abstract void visit(Built_in_funcNode node);
     public abstract void visit(AdditiveExprNode node);

--- a/src/main/java/astvisitors/IndentedPrintVisitor.java
+++ b/src/main/java/astvisitors/IndentedPrintVisitor.java
@@ -127,12 +127,6 @@ public class IndentedPrintVisitor extends AstLevelVisitor {
     }
 
     @Override
-    public void visitLevel(TypeNode node, int level) {
-        System.out.println("In TypeNode");
-
-    }
-
-    @Override
     public void visitLevel(DclsNode node, int level) {
         print(node, level);
         int childCount = node.getChildCount();
@@ -147,12 +141,6 @@ public class IndentedPrintVisitor extends AstLevelVisitor {
         print(node, level);
         node.getExprNode().acceptLevel(this, level + 1);
         node.getBlockNode().acceptLevel(this, level + 1);
-    }
-
-    @Override
-    public void visitLevel(ExprNode node, int level) {
-        System.out.println("In ExprNode");
-
     }
 
     @Override

--- a/src/main/java/astvisitors/SymbolTableVisitor.java
+++ b/src/main/java/astvisitors/SymbolTableVisitor.java
@@ -117,11 +117,6 @@ public class SymbolTableVisitor extends AstVisitor {
     }
 
     @Override
-    public void visit(TypeNode node) {
-
-    }
-
-    @Override
     public void visit(DclsNode node) {
         int childCount = node.getChildCount();
         for (int i = 0; i < childCount; i++) {
@@ -133,11 +128,6 @@ public class SymbolTableVisitor extends AstVisitor {
     public void visit(While_stmtNode node) {
         node.getExprNode().accept(this);
         node.getBlockNode().accept(this);
-    }
-
-    @Override
-    public void visit(ExprNode node) {
-
     }
 
     @Override


### PR DESCRIPTION
Legacy since the `astvisitors` and `astlevelvisitors` aren't supposed to visit abstract classes.