### PR TITLE
Removed leading comma from parameters

### DIFF
--- a/src/main/java/ezuino/Ezuino.g4
+++ b/src/main/java/ezuino/Ezuino.g4
@@ -66,12 +66,18 @@ expr
     : logicalOrExpr
     ;
 func_def
-    : FUNCTION type? ID parameters block;
+    : FUNCTION type? ID '(' parameters ')' block
+    ;
+parameters
+    : dcl(','dcl)*
+    | 
+    ;
 func_call
     : ID '('func_call_param')'
     ;
 func_call_param
-    : expr? | expr(','expr)+
+    : expr(','expr)* 
+    | 
 	;
 val
     : ID
@@ -94,9 +100,6 @@ if_stmt
     ;
 while_stmt
     : WHILE '('expr')' block
-    ;
-parameters
-    : '('dcl?(','dcl)*')'
     ;
 block
     : '{'dcls stmts return_stmt?'}'

--- a/src/test/java/generated/EzuinoLexerTest.java
+++ b/src/test/java/generated/EzuinoLexerTest.java
@@ -522,6 +522,12 @@ public class EzuinoLexerTest {
     }
 
     @Test
+    public void leadingCommaFunctiontest() throws IOException {
+        ErrorHandler errorHandler = parseProgram("func f(, int b){}");
+        assertTrue(errorHandler.hasErrors());
+    }
+
+    @Test
     public void voidReturnFunction() throws IOException {
         ErrorHandler errorHandler = parseProgram("func f(){return 42}");
         assertFalse(errorHandler.hasErrors());


### PR DESCRIPTION
Found a bug.

You could do this:
```
func main(, int a) {
...
}
```